### PR TITLE
squid:S1118, squid:S1170 - Utility classes should not have public con…

### DIFF
--- a/chat-message-view/src/main/java/me/himanshusoni/chatmessageview/util/ViewUtil.java
+++ b/chat-message-view/src/main/java/me/himanshusoni/chatmessageview/util/ViewUtil.java
@@ -5,9 +5,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Created by himanshusoni on 06/09/15.
  */
-public class ViewUtil {
+public final class ViewUtil {
 
     private static final AtomicInteger sNextGeneratedId = new AtomicInteger(1);
+
+    private ViewUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * Generate a value suitable for use in {@link android.view.View#setId(int)}.

--- a/example/src/main/java/me/himanshusoni/chatmessageview/example/ChatMessageAdapter.java
+++ b/example/src/main/java/me/himanshusoni/chatmessageview/example/ChatMessageAdapter.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
  * Created by himanshusoni on 06/09/15.
  */
 public class ChatMessageAdapter extends ArrayAdapter<ChatMessage> {
-    private final int MY_MESSAGE = 0, OTHER_MESSAGE = 1, MY_IMAGE = 2, OTHER_IMAGE = 3;
+    private static final int MY_MESSAGE = 0, OTHER_MESSAGE = 1, MY_IMAGE = 2, OTHER_IMAGE = 3;
 
     public ChatMessageAdapter(Context context, ArrayList<ChatMessage> data) {
         super(context, R.layout.item_mine_message, data);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1118 - Utility classes should not have public constructors
squid:S1170 - Public constants and fields initialized at declaration should be "static final" rather than merely "final"

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170

Please let me know if you have any questions.

M-Ezzat
